### PR TITLE
ENS Domain Address Resolver Addition

### DIFF
--- a/packages/realt-commons/src/components/modals/WalletModal/WalletModal.tsx
+++ b/packages/realt-commons/src/components/modals/WalletModal/WalletModal.tsx
@@ -15,8 +15,9 @@ import { styles } from './WalletModal.styles';
 import { useSetAtom } from 'jotai';
 import { providerAtom } from '../../../states';
 import { useRootStore } from '../../../providers/RealtProvider';
-import { utils } from 'ethers';
+import { utils, ethers } from 'ethers';
 import { AvailableConnectors, ConnectorData, ConnectorMap, ConnectorsDatas } from '../../../web3';
+import { CHAINS, ChainsID } from '../../../config';
 
 type WalletModalButtonProps = {
   onSuccess: () => void;
@@ -110,6 +111,19 @@ export const ReadOnlyAddress = ({ onSuccess, connectorMap, connectorData }: Read
     if(address != "") return;
     setAddress(localStorage.getItem('readOnlyAddress') ?? "");
   },[localStorage])
+
+  useEffect(() => {
+    (async () => {
+      if(!address.endsWith('.eth')) return;
+
+
+      const rpc = CHAINS[ChainsID.Ethereum].rpcUrl;
+      const provider = new ethers.providers.JsonRpcProvider(rpc);
+      const resolvedAddress = await provider.resolveName(address);
+      if(!resolvedAddress) return;
+      setAddress(resolvedAddress);
+    })()
+  },[address])
 
   const onActivating = async () => {
     localStorage.setItem('readOnlyAddress', address)

--- a/packages/realt-commons/src/i18next/locales/en/common.ts
+++ b/packages/realt-commons/src/i18next/locales/en/common.ts
@@ -24,8 +24,8 @@ const common = {
     "readOnly": {
       "title": "Watch an address",
       "description": "You can watch an address but can't do anything else.",
-      "inputPlaceholder": "Address you want to watch",
-      "wrongAddressFormat": "Address not valid",
+      "inputPlaceholder": "Address or ENS domain you want to watch",
+      "wrongAddressFormat": "Address or ENS domain not valid",
       "button": "Watch address"
     } 
   },

--- a/packages/realt-commons/src/i18next/locales/es/common.ts
+++ b/packages/realt-commons/src/i18next/locales/es/common.ts
@@ -24,8 +24,8 @@ const common = {
     "readOnly": {
       "title": "Watch an address",
       "description": "You can watch an address but can't do anything else.",
-      "inputPlaceholder": "Address you want to watch",
-      "wrongAddressFormat": "Address not valid",
+      "inputPlaceholder": "Address or ENS domain you want to watch",
+      "wrongAddressFormat": "Address or ENS domain not valid",
       "button": "Watch address"
     }
   },

--- a/packages/realt-commons/src/i18next/locales/fr/common.ts
+++ b/packages/realt-commons/src/i18next/locales/fr/common.ts
@@ -24,8 +24,8 @@ const common = {
     "readOnly": {
       "title": "Lecture seul",
       "description": "Vous pouvez vous connecter à une adresse en mode lecture seule uniquement.",
-      "inputPlaceholder": "Adresse à visualier",
-      "wrongAddressFormat": "Le format d'adresse n'est pas valide",
+      "inputPlaceholder": "Adresse ou ENS domain à visualier",
+      "wrongAddressFormat": "Le format d'adresse ou de l'ENS domain n'est pas valide",
       "button": "Visualiser avec l'address"
     }
   }  ,


### PR DESCRIPTION
## Overview:
This Pull Request introduces functionality for resolving ENS domain addresses, permitting users to engage with a more instinctual and human-friendly address format.

Key Changes:

- Integrated a service to resolve ENS domains to Ethereum addresses.
- Offers a simplified, human-readable format for interacting with Ethereum addresses.
- Enhances user experience and lowers the entry barrier for those unfamiliar with traditional hexadecimal addresses.

### Files changed :
- WalletModal.tsx
- Locals

## Testing:
- Launch example and try to enter a valid ENS domain name on the address field
- You must seen the input change from the ENS domain name to the corresponding address